### PR TITLE
Fix #184 - "다시 골라밥" 기능 수정

### DIFF
--- a/Gollabab/View/Random/RandomAnimationView.swift
+++ b/Gollabab/View/Random/RandomAnimationView.swift
@@ -55,9 +55,6 @@ struct RandomAnimationView: View {
             }
             .frame(minWidth: .zero, maxWidth: .infinity, minHeight: .zero, maxHeight: .infinity)
             .background(Color.text300)
-            .onAppear {
-                viewModel.startAnimation()
-            }
         }
         .navigationTitle("")
         .navigationBarHidden(true)

--- a/Gollabab/View/Random/RandomResultView.swift
+++ b/Gollabab/View/Random/RandomResultView.swift
@@ -11,6 +11,7 @@ struct RandomResultView: View {
     @ObservedObject var viewModel: MainViewModel
     @State var currentIndex: Int = 0
     @State var isShowToast: Bool = false
+    @State var isRetry: Bool = false
     
     var body: some View {
         ZStack {
@@ -28,7 +29,7 @@ struct RandomResultView: View {
             }
             
             VStack(spacing: 0) {
-                ResultCardScrollView(viewModel: viewModel, currentIndex: $currentIndex)
+                ResultCardScrollView(viewModel: viewModel, currentIndex: $currentIndex, isRetry: $isRetry)
                     .padding(.top, 70)
                     .padding(.bottom, 95)
                 
@@ -48,7 +49,13 @@ struct RandomResultView: View {
                     .padding(.leading, 27)
                     
                     Button {
-                        isShowToast = !viewModel.retryGetRandomPlaces()
+                        if viewModel.retryGetRandomPlaces() {
+                            withAnimation {
+                                isRetry = true
+                            }
+                        } else {
+                            isShowToast = true
+                        }
                     } label: {
                         Text("다시 골라밥")
                             .font(.eliceP1())

--- a/Gollabab/View/Random/ResultCardScrollView.swift
+++ b/Gollabab/View/Random/ResultCardScrollView.swift
@@ -12,6 +12,7 @@ struct ResultCardScrollView: View {
     
     @GestureState var offset: CGFloat = 0
     @Binding var currentIndex: Int
+    @Binding var isRetry: Bool
     
     let limitCount: CGFloat = 3
     let cardWidth: CGFloat = 351 * 0.7
@@ -25,11 +26,21 @@ struct ResultCardScrollView: View {
             
             HStack(spacing: 0) {
                 ForEach(Array(viewModel.randomResult.enumerated()), id: \.0) { idx, place in
-                    ResultCardView(viewModel: viewModel, place: place)
-                        .frame(width: cardWidth)
-                        .background(Color.white)
-                        .cornerRadius(6)
-                        .scaleEffect(idx == currentIndex ? 1.0 : 0.8)
+                    ZStack {
+                        Image("card_shuffle")
+                            .resizable()
+                            .scaleEffect(idx == currentIndex ? 1.0 : 0.8)
+                            .rotation3DEffect(Angle.degrees(isRetry ? 0 : 180), axis: (0,1,0))
+                            .zIndex(isRetry ? 1 : 0)
+                        
+                        ResultCardView(viewModel: viewModel, place: place)
+                            .frame(width: cardWidth)
+                            .background(Color.white)
+                            .cornerRadius(6)
+                            .scaleEffect(idx == currentIndex ? 1.0 : 0.8)
+                            .rotation3DEffect(Angle.degrees(isRetry ? 180 : 360), axis: (0,1,0))
+                            .zIndex(isRetry ? 0 : 1)
+                    }
                 }
             }
             .padding(.leading, 20)

--- a/Gollabab/ViewModel/MainViewModel.swift
+++ b/Gollabab/ViewModel/MainViewModel.swift
@@ -369,10 +369,6 @@ class MainViewModel: ObservableObject {
         return true
     }
     
-    func startAnimation() {
-        moveIndex = 30
-    }
-    
     // MARK: - Random Result View
     func getMidIndex() -> Int {
         guard randomResult.count != 0 else { return 0 }


### PR DESCRIPTION
* 다시 골라밥 클릭 시 미리 결과가 보이고 화면전환이 이루어짐
* 간단하게 해결하기 위해 버튼 클릭 시 카드를 뒤집고 화면전환하는 방식으로 구현